### PR TITLE
Sequencer writes to a memmapped file, client-service tasks read from it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/test_output
+/sequencer_server/test_output

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /test_output
 /sequencer_server/test_output
+messagebus

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +857,7 @@ dependencies = [
  "clap 3.1.18",
  "criterion",
  "futures",
+ "fxhash",
  "hex",
  "lazy_static",
  "memmap2",
@@ -979,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.18.2"
+version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
+checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
 name = "bytecheck"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,10 +88,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
 
 [[package]]
 name = "clap"
@@ -89,7 +140,7 @@ dependencies = [
  "lazy_static",
  "strsim",
  "termcolor",
- "textwrap",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
@@ -115,6 +166,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap 2.34.0",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,8 +282,14 @@ checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -163,6 +329,36 @@ checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg",
  "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "js-sys"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -212,6 +408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +426,25 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -238,6 +462,12 @@ name = "once_cell"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "os_str_bytes"
@@ -293,6 +523,34 @@ name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -357,6 +615,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +646,27 @@ checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "rend"
@@ -400,6 +703,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +739,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "semver"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+
+[[package]]
 name = "sequencer_common"
 version = "0.1.0"
 dependencies = [
@@ -419,7 +752,7 @@ dependencies = [
  "bytecheck",
  "byteorder",
  "bytes",
- "clap",
+ "clap 3.1.18",
  "memmap2",
  "pin-project",
  "rkyv",
@@ -434,13 +767,53 @@ dependencies = [
  "bytecheck",
  "byteorder",
  "bytes",
- "clap",
+ "chrono",
+ "clap 3.1.18",
+ "criterion",
  "lazy_static",
  "memmap2",
  "pin-project",
  "rkyv",
  "sequencer_common",
  "tokio",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+dependencies = [
+ "itoa 1.0.2",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -496,9 +869,39 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "tokio"
@@ -538,6 +941,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unsequenced_producer"
 version = "0.1.0"
 dependencies = [
@@ -554,16 +963,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+name = "walkdir"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+
+[[package]]
+name = "web-sys"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,19 +103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +262,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+
+[[package]]
+name = "futures-task"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-util"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +396,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "indexmap"
@@ -429,16 +511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +595,12 @@ name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
@@ -767,9 +845,10 @@ dependencies = [
  "bytecheck",
  "byteorder",
  "bytes",
- "chrono",
  "clap 3.1.18",
  "criterion",
+ "futures",
+ "hex",
  "lazy_static",
  "memmap2",
  "pin-project",
@@ -824,6 +903,12 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
@@ -881,17 +966,6 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
 
 [[package]]
 name = "tinytemplate"

--- a/sequencer_common/src/lib.rs
+++ b/sequencer_common/src/lib.rs
@@ -13,9 +13,10 @@ pub type EpochId = u16;
 pub type InstanceId = u16;
 pub type ClusterId = u16;
 
-/// Messages going into the sequencer server and being sent out by the sequencer
-/// server over the bus are the same structure, to make 0-copy behavior
-/// possible.
+/// Messages going into the sequencer server and 
+/// being sent out by the sequencer
+/// server over the bus are the same structure, 
+/// to make 0-copy behavior possible.
 #[derive(Archive, Deserialize, Serialize, Debug, PartialEq, Eq)]
 #[archive(compare(PartialEq))]
 #[archive_attr(derive(CheckBytes, Debug))]
@@ -58,7 +59,7 @@ impl SequencerMessage {
 impl ArchivedSequencerMessage {
     #[inline(always)]
     // This is the pin projection from SequencerMessage -> sequence_number
-    pub fn with_sequence_number(self: Pin<&mut Self>, value: u64) -> Pin<&mut Self> {
+    pub fn modify_sequence_number(self: Pin<&mut Self>, value: u64) -> Pin<&mut Self> {
         // Sequence number is not a reference type and does not contain any reference
         // types, so this unsafe block *should* be good here.
         unsafe {

--- a/sequencer_common/src/lib.rs
+++ b/sequencer_common/src/lib.rs
@@ -13,6 +13,8 @@ pub type EpochId = u16;
 pub type InstanceId = u16;
 pub type ClusterId = u16;
 
+pub type LengthTag = u16;
+
 /// Messages going into the sequencer server and
 /// being sent out by the sequencer
 /// server over the bus are the same structure,

--- a/sequencer_common/src/lib.rs
+++ b/sequencer_common/src/lib.rs
@@ -13,9 +13,9 @@ pub type EpochId = u16;
 pub type InstanceId = u16;
 pub type ClusterId = u16;
 
-/// Messages going into the sequencer server and 
+/// Messages going into the sequencer server and
 /// being sent out by the sequencer
-/// server over the bus are the same structure, 
+/// server over the bus are the same structure,
 /// to make 0-copy behavior possible.
 #[derive(Archive, Deserialize, Serialize, Debug, PartialEq, Eq)]
 #[archive(compare(PartialEq))]

--- a/sequencer_server/Cargo.toml
+++ b/sequencer_server/Cargo.toml
@@ -17,4 +17,6 @@ rkyv = { version = "0.7", features = ["validation", "size_32", "alloc"] }
 tokio = { version = "1.16", features = ["full", "time", "rt", "rt-multi-thread"] }
 
 [dev-dependencies]
+chrono = "0.4.19"
+criterion = "0.3"
 lazy_static = "1.4.0"

--- a/sequencer_server/Cargo.toml
+++ b/sequencer_server/Cargo.toml
@@ -11,12 +11,13 @@ byteorder = { version = "1.3" }
 bytes = { version = "1.1.0" }
 bytecheck = { version = "*" }
 clap = { version = "3.1", features = ["derive"] }
+futures = "0.3"
 memmap2 = "0.5"
 pin-project = "1.0.10"
 rkyv = { version = "0.7", features = ["validation", "size_32", "alloc"] }
 tokio = { version = "1.16", features = ["full", "time", "rt", "rt-multi-thread"] }
 
 [dev-dependencies]
-chrono = "0.4.19"
 criterion = "0.3"
+hex = "0.4.3"
 lazy_static = "1.4.0"

--- a/sequencer_server/Cargo.toml
+++ b/sequencer_server/Cargo.toml
@@ -12,10 +12,11 @@ bytes = { version = "1.1.0" }
 bytecheck = { version = "*" }
 clap = { version = "3.1", features = ["derive"] }
 futures = "0.3"
+fxhash = "0.2"
 memmap2 = "0.5"
 pin-project = "1.0.10"
 rkyv = { version = "0.7", features = ["validation", "size_32", "alloc"] }
-tokio = { version = "1.16", features = ["full", "time", "rt", "rt-multi-thread"] }
+tokio = { version = "1.19", features = ["full", "time", "rt", "rt-multi-thread"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/sequencer_server/src/main.rs
+++ b/sequencer_server/src/main.rs
@@ -250,13 +250,9 @@ mod test {
         static ref IO_TEST_PERMISSIONS: Mutex<()> = Mutex::new(());
     }
 
-    /*
     #[tokio::test(flavor = "multi_thread")]
     async fn test_stream_received() {
-        use rkyv::Archive;
         use rkyv::Deserialize;
-        use std::time::Duration;
-        use tokio::time::timeout;
 
         // Prevent tests from interfering with eachother over the localhost connection.
         // This should implicitly drop when the test ends.
@@ -297,7 +293,7 @@ mod test {
         // Extract a message back out
         // This always returns With<_, _>, no matter 
         // how I try to finagle it. So, commenting this test out for now. 
-        let deserialized: SequencerMessage = message.deserialize(&mut rkyv::Infallible::default()).unwrap();
+        let deserialized: SequencerMessage = message.as_ref().get_ref().deserialize(&mut rkyv::Infallible::default()).unwrap();
 
         // Validate the way the sequencer parsed the message.
         assert_eq!(deserialized.app_id, input.app_id);
@@ -308,7 +304,7 @@ mod test {
         let deserialized_message = String::from_utf8_lossy(&deserialized.payload);
 
         assert_eq!(example_message, deserialized_message);
-    }*/
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_counter() {

--- a/sequencer_server/src/main.rs
+++ b/sequencer_server/src/main.rs
@@ -1183,9 +1183,9 @@ mod test {
                 if num_messages_received >= NUM_TESTS { 
                     break;
                 }
-                let read_resl = tcp_stream.read_u16().await;
+                let read_resl = tcp_stream.read_u16_le().await;
                 let length_tag = read_resl.unwrap();
-                if length_tag != 0  { 
+                if length_tag != 0 {
                     let mut message_buf = vec![0u8; length_tag as usize]; 
                     total_bytes_received += std::mem::size_of::<LengthTag>();
                     tcp_stream.read_exact(&mut message_buf).await.unwrap(); 

--- a/sequencer_server/src/record.rs
+++ b/sequencer_server/src/record.rs
@@ -380,7 +380,7 @@ impl MemMapRecordReader {
             if app_ids.is_empty() { 
                 // No whitelist, match all. 
                 // Length tag 
-                writer.write_u16(message.len() as u16).await?;
+                writer.write_u16_le(message.len() as u16).await?;
                 // Write the message.
                 writer.write_all(message).await?;
             }
@@ -393,7 +393,7 @@ impl MemMapRecordReader {
                 };
                 if app_ids.contains(&data.app_id) { 
                     // Length tag 
-                    writer.write_u16(message.len() as u16).await?;
+                    writer.write_u16_le(message.len() as u16).await?;
                     // Write the message.
                     writer.write_all(message).await?;
                 }

--- a/sequencer_server/src/record.rs
+++ b/sequencer_server/src/record.rs
@@ -2,16 +2,17 @@
 //! message bus. The sequencer's message history is split into two memory-mapped
 //! ring buffer files, one of which contains the current
 
+use memmap2::{MmapMut, MmapOptions, Mmap};
+
+//use rkyv::validation::CheckArchiveError;
+use sequencer_common::{LengthTag, AppId, SequencerMessage};
+use tokio::io::{AsyncWrite, AsyncWriteExt}; 
+
 use std::{
     fs::{File, OpenOptions},
     io::{Seek, SeekFrom, Write},
-    path::Path,
+    path::Path, fmt::Display,
 };
-
-use memmap2::{MmapMut, MmapOptions};
-
-pub(crate) type LengthTag = u16;
-pub(crate) const LENGTH_TAG_LEN: usize = std::mem::size_of::<LengthTag>();
 
 /// How many bytes should we add to the file when it's time to grow the file?
 const GROW_BY: usize = 65535;
@@ -42,15 +43,6 @@ pub struct MemMapBackend {
 impl MemMapBackend {
     #[inline]
     fn grow_if_needed(&mut self, additional_bytes_len: u64) -> Result<(), std::io::Error> {
-        #[cfg(debug_assertions)]
-        {
-            println!(
-                "File is currently {} bytes long, assessing if it needs to grow to add {}...",
-                self.file.metadata().unwrap().len(),
-                additional_bytes_len
-            )
-        }
-
         if (self.current_offset + additional_bytes_len) > self.current_file_len {
             let to_grow = GROW_BY.max(additional_bytes_len as usize);
             let new_len = self.current_file_len + to_grow as u64;
@@ -66,7 +58,7 @@ impl MemMapBackend {
 
             // Zeroize the next length tag (null terminate) and don't advance the cursor or
             // current offset (so it can get overwritten)
-            let zeroes = [0u8; LENGTH_TAG_LEN];
+            let zeroes = [0u8; std::mem::size_of::<LengthTag>()];
             self.file.write_all(&zeroes)?;
             self.file.seek(SeekFrom::Start(self.current_file_len))?;
 
@@ -110,6 +102,12 @@ impl MessageRecordBackend for MemMapBackend {
 
         let file_len = file.seek(SeekFrom::End(0))?;
 
+        if file_len == 0 {
+            file.set_len(GROW_BY as u64)?;
+        }
+        let file_len = file.seek(SeekFrom::End(0))?;
+        file.seek(SeekFrom::Start(0))?;
+
         let start_offset = if start_offset > file_len {
             println!("WARNING: Attempting to start at an offset which the message bus has not reached yet. Defaulting to end of file.");
             eprintln!("WARNING: Attempting to start at an offset which the message bus has not reached yet. Defaulting to end of file.");
@@ -151,13 +149,13 @@ impl MessageRecordBackend for MemMapBackend {
         let message_len = message.as_ref().len() as usize;
         assert!(message_len < LengthTag::MAX as usize);
         // Total new bytes to append.
-        let additional_len = (LENGTH_TAG_LEN + message_len) as usize;
+        let additional_len = (std::mem::size_of::<LengthTag>() + message_len) as usize;
         // End of length prefix, start of message payload.
         //let message_start = self.current_offset + LENGTH_PREFIX_LEN as u64;
         // Length prefix bytes.
         // TODO: Discuss with team - are we sure we want little-endian?
         let len_bytes = (message.as_ref().len() as LengthTag).to_le_bytes();
-        let full_len = LENGTH_TAG_LEN + message_len as usize;
+        let full_len = std::mem::size_of::<LengthTag>() + message_len as usize;
         // How long will the file need to be to contain this new information?
         let new_record_end = self.current_offset + additional_len as u64;
 
@@ -180,20 +178,20 @@ impl MessageRecordBackend for MemMapBackend {
         //    .copy_from_slice(message.as_ref());
 
         // Push our length prefix.
-        self.mmap[self.mmap_cursor..self.mmap_cursor + LENGTH_TAG_LEN].copy_from_slice(&len_bytes);
+        self.mmap[self.mmap_cursor..self.mmap_cursor + std::mem::size_of::<LengthTag>()].copy_from_slice(&len_bytes);
         // Push our message.
-        self.mmap[self.mmap_cursor + LENGTH_TAG_LEN..self.mmap_cursor + full_len]
+        self.mmap[self.mmap_cursor + std::mem::size_of::<LengthTag>()..self.mmap_cursor + full_len]
             .copy_from_slice(message.as_ref());
 
         let mut written_len = full_len;
 
         // Zeroize the next length tag, and don't advance the cursor or current offset
         // (so it can get overwritten)
-        if (self.current_offset + full_len as u64 + LENGTH_TAG_LEN as u64) > self.current_file_len {
-            let zeroes = [0u8; LENGTH_TAG_LEN];
-            self.mmap[self.mmap_cursor + full_len..self.mmap_cursor + full_len + LENGTH_TAG_LEN]
+        if (self.current_offset + full_len as u64 + std::mem::size_of::<LengthTag>() as u64) > self.current_file_len {
+            let zeroes = [0u8; std::mem::size_of::<LengthTag>()];
+            self.mmap[self.mmap_cursor + full_len..self.mmap_cursor + full_len + std::mem::size_of::<LengthTag>()]
                 .copy_from_slice(&zeroes);
-            written_len += LENGTH_TAG_LEN;
+            written_len += std::mem::size_of::<LengthTag>();
         }
 
         self.mmap.flush_range(self.mmap_cursor, written_len)?;
@@ -209,6 +207,220 @@ impl MessageRecordBackend for MemMapBackend {
     }
     fn record_len(&self) -> u64 {
         self.current_offset
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum RecordReadError {
+    InvalidLength(usize, usize, usize)
+}
+
+impl Display for RecordReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RecordReadError::InvalidLength(message_length, current_cursor, file_end) => write!(
+                f,
+                "Attempted to read a message of length {}, starting from position {}, which would take us past the end of the file which is at position {}",
+                message_length, 
+                current_cursor, 
+                file_end,
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RecordReadError {}
+
+pub struct RecordReader<'a> {
+    cursor: usize,
+    data: &'a [u8],
+}
+
+impl<'a> RecordReader<'a> {
+    pub fn new(data: &'a [u8]) -> Self { 
+        Self {
+            cursor: 0, 
+            data 
+        }
+    }
+    pub fn get_cursor(&self) -> usize { 
+        self.cursor
+    }
+    /// Returns Ok(None) if we've reached the end of our record. 
+    pub fn get_next(&mut self) ->  Result<Option<&'a [u8]>, RecordReadError> { 
+        let mut length_tag_bytes = [0u8; std::mem::size_of::<LengthTag>()];
+        length_tag_bytes.copy_from_slice(&self.data[self.cursor..self.cursor + std::mem::size_of::<LengthTag>()]);
+        let message_length = LengthTag::from_le_bytes(length_tag_bytes) as usize;
+        //length tag specifying zero is EOF
+        if message_length == 0 {
+            return Ok(None);
+        }
+        if self.cursor + std::mem::size_of::<LengthTag>() + message_length > self.data.len() { 
+            return Err(RecordReadError::InvalidLength( message_length + std::mem::size_of::<LengthTag>(), self.cursor, self.data.len()));
+        }
+
+        self.cursor += std::mem::size_of::<LengthTag>();
+        let message = &self.data[self.cursor..self.cursor+message_length];
+        self.cursor += message_length;
+
+        Ok(Some(message))
+    }
+
+}
+
+impl<'a> Iterator for RecordReader<'a> { 
+    type Item = Result<&'a [u8], RecordReadError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.get_next() { 
+            Ok(Some(msg)) => Some(Ok(msg)),
+            Ok(None) => None, 
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum MmapReadError {
+    /// Record read issue, probably related to length tag. 
+    RecordReadLogic(RecordReadError),
+    IoError(std::io::Error),
+    CheckArchive(String),
+}
+
+impl Display for MmapReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MmapReadError::RecordReadLogic(e) => write!(
+                f,
+                "{:?}",
+                e,
+            ),
+            MmapReadError::IoError(e) => write!(
+                f, 
+                "Could not read a memory-mapped message record due to io error: {:?}",
+                e
+            ),
+            MmapReadError::CheckArchive(e) => write!(
+                f, 
+                "Failed to validate message structure when parsing to check app ID: {}",
+                e
+            ),
+        }
+    }
+}
+impl std::error::Error for MmapReadError {}
+
+impl From<RecordReadError> for MmapReadError {
+    fn from(e: RecordReadError) -> Self {
+        MmapReadError::RecordReadLogic(e)
+    }
+}
+impl From<std::io::Error> for MmapReadError {
+    fn from(e: std::io::Error) -> Self {
+        MmapReadError::IoError(e)
+    }
+}
+
+pub struct MemMapRecordReader {
+    pub(in crate::record) mmap: Mmap,
+    /// How far, in absolute terms, have we got in this epoch's global byte stream? 
+    pub(in crate::record) start_offset: u64,
+    /// How far has this reader gotten into the mmap?
+    /// NOTE - mmap 0 starts at start_offset. This does not correspond to a global stream index. 
+    pub(in crate::record) last_read_offset: u64,
+}
+
+// No remap option because the behavior of MemMapRecordReader.new (file, old.most_recent_offset_visited()) 
+// would be identical to what remap would do anyway.
+
+impl MemMapRecordReader {
+    pub fn new<T: AsRef<Path>>(file_path: T, start_offset: u64) -> Result<Self, std::io::Error> { 
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(false)
+            .open(file_path)?;
+
+        let file_len = file.seek(SeekFrom::End(0))?;
+
+        let start_offset = if start_offset > file_len {
+            println!("WARNING: Attempting to start at an offset which the message bus has not reached yet. Defaulting to 0.");
+            eprintln!("WARNING: Attempting to start at an offset which the message bus has not reached yet. Defaulting to 0.");
+            file_len
+        } else {
+            start_offset
+        };
+
+        file.seek(SeekFrom::Start(start_offset))?;
+
+        let mut options = MmapOptions::default();
+        options.offset(start_offset);
+
+        let mmap = unsafe { options.map(&file)? };
+
+        Ok(Self {
+            mmap,
+            start_offset,
+            last_read_offset: 0, //Remember, it's in mmap-space, not global-space.
+        })
+    }
+
+    /// Attempt to read messages from between the last index we left off on, and self.mmap.len(),
+    /// checking to see if app_id matches one of the IDs on the provided array and only pushing if it does.
+    /// 
+    /// Providing an empty set of app IDs causes this object to send regardless / ignore the message's app ID. 
+    /// 
+    /// This method should be fully zero-copy, end-to-end, unless the OS performs its own copy when we 
+    /// push to the socket.
+    pub async fn read_and_push_to<W: AsyncWrite + AsyncWriteExt + Unpin>(&mut self, app_ids: &[AppId], writer: &mut W) -> Result<u64, MmapReadError> { 
+        let mut reader = RecordReader::new(&self.mmap.as_ref()[self.last_read_offset as usize ..]);
+        while let Some(maybe_message) = reader.next() {
+            let message = maybe_message?;
+
+            if app_ids.is_empty() { 
+                // No whitelist, match all. 
+                // Length tag 
+                writer.write_u16(message.len() as u16).await?;
+                // Write the message.
+                writer.write_all(message).await?;
+            }
+            else {
+                rkyv::check_archived_root::<SequencerMessage>(message)
+                    .map_err(|e| MmapReadError::CheckArchive(format!("{:?}", e)))?;
+
+                let data = unsafe {
+                    rkyv::archived_root::<SequencerMessage>(message)
+                };
+                if app_ids.contains(&data.app_id) { 
+                    // Length tag 
+                    writer.write_u16(message.len() as u16).await?;
+                    // Write the message.
+                    writer.write_all(message).await?;
+                }
+            }
+        }
+        let amt_written = reader.cursor as u64 - self.last_read_offset;
+        self.last_read_offset += reader.cursor as u64;
+        Ok(amt_written)
+    }
+    /// This mostly exists for tests - in production you will, generally, want to use read_and_push_to() as that is zero-copy. 
+    pub fn read_all(&mut self) -> Result<Vec<Vec<u8>>, MmapReadError>  {
+        let mut all_messages = Vec::new();
+        let mut reader = RecordReader::new(&self.mmap.as_ref()[self.last_read_offset as usize ..]);
+        while let Some(maybe_message) = reader.next() {
+            let message = maybe_message?; 
+            all_messages.push(message.to_vec());
+        }
+        self.last_read_offset += reader.cursor as u64;
+        Ok(all_messages)
+    }
+    /// How far in terms of global stream offset (total bytes sent this epoch) have we gotten? 
+    pub fn most_recent_offset_visited(&self) -> u64 { 
+        self.last_read_offset + self.start_offset
+    }
+    /// Where in the global stream offset (total bytes sent this epoch) does our currently-mapped range end? 
+    pub fn range_end(&self) -> u64 { 
+        self.start_offset + self.mmap.as_ref().len() as u64 
     }
 }
 

--- a/sequencer_server/src/record.rs
+++ b/sequencer_server/src/record.rs
@@ -1,3 +1,192 @@
 //! A record / history of all messages sent on this consistently-sequenced
 //! message bus. The sequencer's message history is split into two memory-mapped
 //! ring buffer files, one of which contains the current
+
+use std::{future::Future, path::Path, fs::{File, OpenOptions}, io::{SeekFrom, Seek}};
+
+use futures::future;
+use memmap2::MmapOptions;
+
+pub trait MessageRecordBackend : Sized {
+    type WriteMsgFuture: Future<Output=Result<(), std::io::Error>>; 
+
+    fn init<T: AsRef<Path>>(file_path: T) -> Result<Self, std::io::Error>; 
+    fn write_message<T: AsRef<[u8]>>(&mut self, message: T) -> Self::WriteMsgFuture; 
+    /// How long was this file when we opened it, at the start of this run of the program? 
+    fn initial_offset(&self) -> u64;
+    /// How many bytes total comprise this record? 
+    fn record_len(&self) -> u64;
+}
+
+pub struct MemMapBackend { 
+    file: File,
+    //mmap: MmapMut, TODO: Find a way to make mmap growable
+    start_offset: u64,
+    current_offset: u64, 
+}
+
+impl MessageRecordBackend for MemMapBackend {
+    type WriteMsgFuture = futures::future::Ready<Result<(), std::io::Error>>;
+
+    fn init<T: AsRef<Path>>(file_path: T) -> Result<Self, std::io::Error> {
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .append(true)
+            .create(true)
+            .open(file_path)?;
+        
+        let file_len = file.seek(SeekFrom::End(0))?;
+
+        /*
+        let mut options = MmapOptions::default();
+        // Append - start at the end of the file. 
+        options.offset(file_len);
+
+        // There is, apparently, no such thing as a "safe" memory map
+        // since, at an OS level, not much safety is built in -
+        // other processes can change them out from under you.
+        let mmap = unsafe { options.map_mut(&file)? };
+
+        #[cfg(unix)]
+        { 
+            // This is a Unix-only feature so there is no 
+            // perf hint on, for example, Azure.
+            mmap.advise(memmap2::Advice::Sequential)?;
+        }
+*/
+        Ok(
+            Self {
+                file,
+                start_offset: file_len,
+                current_offset: file_len,
+            }
+        )
+    }
+
+    #[inline]
+    fn write_message<T: AsRef<[u8]>>(&mut self, message: T) -> Self::WriteMsgFuture {
+        // Length of message payload to append.
+        let message_len = message.as_ref().len() as u64; 
+        // Total new bytes to append.
+        let additional_len: u64 = std::mem::size_of::<u64>() as u64 + message_len;
+        // End of length prefix, start of message payload.
+        let message_start = self.current_offset + std::mem::size_of::<u64>() as u64;
+        // Length prefix bytes.
+        // TODO: Discuss with team - are we sure we want little-endian? 
+        let len_bytes = (message.as_ref().len() as u64).to_le_bytes();
+        // How long will the file need to be to contain this new information?
+        let new_file_end = self.current_offset + additional_len;
+
+        // Expand file.
+        match self.file.set_len(new_file_end) {
+            Ok(_) => { /* continue */},  
+            Err(e) => return future::err(e.into()),
+        };
+
+        let mut options = MmapOptions::default();
+        // Append - start at the end of the file. 
+        options.offset(self.current_offset);
+
+        // There is, apparently, no such thing as a "safe" memory map
+        // since, at an OS level, not much safety is built in -
+        // other processes can change them out from under you.
+        let mut mmap = unsafe { 
+            match options.map_mut(&self.file) {
+                Ok(m) => m, 
+                Err(e) => return future::err(e),   
+            } 
+        };
+
+        /*#[cfg(unix)]
+        { 
+            // This is a Unix-only feature so there is no 
+            // perf hint on, for example, Azure.
+            if let Err(e) = mmap.advise(memmap2::Advice::Sequential) {
+                return future::err(e);
+            }
+        }*/
+
+        // Push our length prefix. 
+        mmap[self.current_offset as usize .. message_start as usize]
+            .copy_from_slice(&len_bytes);
+
+        // Push our message.
+        mmap[message_start as usize .. new_file_end as usize]
+            .copy_from_slice(message.as_ref());
+        
+        match mmap.flush_range(self.current_offset as usize, additional_len as usize) {
+            Ok(_) => {
+                // Update our current offset counter.
+                self.current_offset = new_file_end;
+                future::ok(())
+            },
+            Err(e) => future::err(e.into()),
+        }
+    }
+    fn initial_offset(&self) -> u64 { 
+        self.start_offset
+    }
+    fn record_len(&self) -> u64 { 
+        self.current_offset
+    }
+}
+
+#[cfg(test)]
+pub mod test_util {
+    use futures::future;
+
+    use super::MessageRecordBackend;
+
+    pub struct DummyBackend{}
+
+    impl MessageRecordBackend for DummyBackend {
+        type WriteMsgFuture = futures::future::Ready<Result<(), std::io::Error>>;
+
+        #[allow(unused_variables)]
+        fn init<T: AsRef<std::path::Path>>(file_path: T) -> Result<Self, std::io::Error> {
+            Ok(DummyBackend{})
+        }
+
+        #[allow(unused_variables)]
+        fn write_message<T: AsRef<[u8]>>(&mut self, message: T) -> Self::WriteMsgFuture {
+            future::ok(())
+        }
+
+        fn initial_offset(&self) -> u64 { 0 }
+        fn record_len(&self) -> u64 { 0 }
+    }
+    
+    pub struct VecBackend{
+        pub inner: Vec<u8>,
+    }
+
+    impl MessageRecordBackend for VecBackend {
+        type WriteMsgFuture = futures::future::Ready<Result<(), std::io::Error>>;
+
+        #[allow(unused_variables)]
+        fn init<T: AsRef<std::path::Path>>(file_path: T) -> Result<Self, std::io::Error> {
+            Ok(
+                VecBackend{
+                    inner: Vec::default(),
+                }
+            )
+        }
+
+        #[allow(unused_variables)]
+        fn write_message<T: AsRef<[u8]>>(&mut self, message: T) -> Self::WriteMsgFuture {
+            // Length-prefixing. 
+            let len_bytes = message.as_ref().len().to_le_bytes();
+            self.inner.extend_from_slice(&len_bytes);
+            // Write message.
+            self.inner.extend_from_slice(message.as_ref());
+            future::ok(())
+        }
+
+        fn initial_offset(&self) -> u64 { 0 }
+        fn record_len(&self) -> u64 {
+            self.inner.len() as u64
+        }
+    }
+
+}

--- a/sequencer_server/src/record.rs
+++ b/sequencer_server/src/record.rs
@@ -2,26 +2,31 @@
 //! message bus. The sequencer's message history is split into two memory-mapped
 //! ring buffer files, one of which contains the current
 
-use std::{path::Path, fs::{File, OpenOptions}, io::{SeekFrom, Seek, Write}};
+use std::{
+    fs::{File, OpenOptions},
+    io::{Seek, SeekFrom, Write},
+    path::Path,
+};
 
-use memmap2::{MmapOptions, MmapMut};
+use memmap2::{MmapMut, MmapOptions};
 
-pub(crate) type LengthTag = u16; 
+pub(crate) type LengthTag = u16;
 pub(crate) const LENGTH_TAG_LEN: usize = std::mem::size_of::<LengthTag>();
 
 /// How many bytes should we add to the file when it's time to grow the file?
 const GROW_BY: usize = 65535;
 
-pub trait MessageRecordBackend : Sized {
-    fn init<T: AsRef<Path>>(file_path: T, start_offset: u64) -> Result<Self, std::io::Error>; 
-    fn write_message<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), std::io::Error>; 
-    /// How long was this file when we opened it, at the start of this run of the program? 
+pub trait MessageRecordBackend: Sized {
+    fn init<T: AsRef<Path>>(file_path: T, start_offset: u64) -> Result<Self, std::io::Error>;
+    fn write_message<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), std::io::Error>;
+    /// How long was this file when we opened it, at the start of this run of
+    /// the program?
     fn initial_offset(&self) -> u64;
-    /// How many bytes total comprise this record? 
+    /// How many bytes total comprise this record?
     fn record_len(&self) -> u64;
 }
 
-pub struct MemMapBackend { 
+pub struct MemMapBackend {
     file: File,
     //mmap: MmapMut, TODO: Find a way to make mmap growable
     start_offset: u64,
@@ -29,7 +34,7 @@ pub struct MemMapBackend {
     current_offset: u64,
     //How big is the file right now? (i.e. current_record_len plus empty space)
     current_file_len: u64,
-    //Resets to 0 every time we grow the file - needed to find where we are in the memmap slice. 
+    //Resets to 0 every time we grow the file - needed to find where we are in the memmap slice.
     mmap_cursor: usize,
     mmap: MmapMut,
 }
@@ -37,45 +42,53 @@ pub struct MemMapBackend {
 impl MemMapBackend {
     #[inline]
     fn grow_if_needed(&mut self, additional_bytes_len: u64) -> Result<(), std::io::Error> {
-        #[cfg(debug_assertions)] { 
-            println!("File is currently {} bytes long, assessing if it needs to grow to add {}...", self.file.metadata().unwrap().len(), additional_bytes_len)
+        #[cfg(debug_assertions)]
+        {
+            println!(
+                "File is currently {} bytes long, assessing if it needs to grow to add {}...",
+                self.file.metadata().unwrap().len(),
+                additional_bytes_len
+            )
         }
 
-        if (self.current_offset + additional_bytes_len) > self.current_file_len { 
+        if (self.current_offset + additional_bytes_len) > self.current_file_len {
             let to_grow = GROW_BY.max(additional_bytes_len as usize);
             let new_len = self.current_file_len + to_grow as u64;
 
-            #[cfg(debug_assertions)] { 
+            #[cfg(debug_assertions)]
+            {
                 println!("Growing file to {}...", new_len);
             }
 
             // Expand file.
             self.file.set_len(new_len)?;
             self.file.seek(SeekFrom::Start(self.current_file_len))?;
-            
-            // Zeroize the next length tag (null terminate) and don't advance the cursor or current offset (so it can get overwritten)
+
+            // Zeroize the next length tag (null terminate) and don't advance the cursor or
+            // current offset (so it can get overwritten)
             let zeroes = [0u8; LENGTH_TAG_LEN];
             self.file.write_all(&zeroes)?;
             self.file.seek(SeekFrom::Start(self.current_file_len))?;
-                
+
             self.current_file_len = new_len;
-            self.mmap = { 
-                
+            self.mmap = {
                 let mut options = MmapOptions::default();
-                // Append - start at the end of the file. 
+                // Append - start at the end of the file.
                 options.offset(self.current_offset);
                 options.len(new_len as usize - self.current_offset as usize);
 
-                #[cfg(debug_assertions)] { 
-                    println!("Memory map will start at {} and be {} bytes long", self.current_offset, to_grow);
+                #[cfg(debug_assertions)]
+                {
+                    println!(
+                        "Memory map will start at {} and be {} bytes long",
+                        self.current_offset, to_grow
+                    );
                 }
 
                 // There is, apparently, no such thing as a "safe" memory map
                 // since, at an OS level, not much safety is built in -
                 // other processes can change them out from under you.
-                unsafe {
-                    options.map_mut(&self.file)?
-                }
+                unsafe { options.map_mut(&self.file)? }
             };
             self.mmap_cursor = 0;
         }
@@ -94,18 +107,18 @@ impl MessageRecordBackend for MemMapBackend {
             .append(true)
             .create(true)
             .open(file_path)?;
-        
+
         let file_len = file.seek(SeekFrom::End(0))?;
 
-        let start_offset = if start_offset > file_len { 
+        let start_offset = if start_offset > file_len {
             println!("WARNING: Attempting to start at an offset which the message bus has not reached yet.");
             file_len
-        } else { 
+        } else {
             start_offset
         };
-        
+
         let mut options = MmapOptions::default();
-        // Append - start at the end of the file. 
+        // Append - start at the end of the file.
         options.offset(start_offset);
 
         // There is, apparently, no such thing as a "safe" memory map
@@ -115,35 +128,33 @@ impl MessageRecordBackend for MemMapBackend {
 
         /*
         #[cfg(unix)]
-        { 
-            // This is a Unix-only feature so there is no 
+        {
+            // This is a Unix-only feature so there is no
             // perf hint on, for example, Azure.
             mmap.advise(memmap2::Advice::Sequential)?;
         }*/
 
-        Ok(
-            Self {
-                file,
-                start_offset,
-                current_offset: start_offset,
-                current_file_len: file_len,
-                mmap_cursor: 0,
-                mmap,
-            }
-        )
+        Ok(Self {
+            file,
+            start_offset,
+            current_offset: start_offset,
+            current_file_len: file_len,
+            mmap_cursor: 0,
+            mmap,
+        })
     }
 
     #[inline]
     fn write_message<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), std::io::Error> {
         // Length of message payload to append.
-        let message_len = message.as_ref().len() as usize; 
+        let message_len = message.as_ref().len() as usize;
         assert!(message_len < LengthTag::MAX as usize);
         // Total new bytes to append.
         let additional_len = (LENGTH_TAG_LEN + message_len) as usize;
         // End of length prefix, start of message payload.
         //let message_start = self.current_offset + LENGTH_PREFIX_LEN as u64;
         // Length prefix bytes.
-        // TODO: Discuss with team - are we sure we want little-endian? 
+        // TODO: Discuss with team - are we sure we want little-endian?
         let len_bytes = (message.as_ref().len() as LengthTag).to_le_bytes();
         let full_len = LENGTH_TAG_LEN + message_len as usize;
         // How long will the file need to be to contain this new information?
@@ -153,37 +164,37 @@ impl MessageRecordBackend for MemMapBackend {
         self.grow_if_needed(additional_len as u64)?;
 
         /*#[cfg(unix)]
-        { 
-            // This is a Unix-only feature so there is no 
+        {
+            // This is a Unix-only feature so there is no
             // perf hint on, for example, Azure.
             if let Err(e) = mmap.advise(memmap2::Advice::Sequential) {
                 return future::err(e);
             }
         }*/
- 
-        // Current range of the memory map right now appears to be offset..len - this affects how the slice works. 
-        //mmap[self.current_offset as usize .. message_start as usize]
-        //    .copy_from_slice(&len_bytes);
+
+        // Current range of the memory map right now appears to be offset..len - this
+        // affects how the slice works. mmap[self.current_offset as usize ..
+        // message_start as usize]    .copy_from_slice(&len_bytes);
         //mmap[message_start as usize .. new_file_end as usize]
         //    .copy_from_slice(message.as_ref());
 
         // Push our length prefix.
-        self.mmap[self.mmap_cursor .. self.mmap_cursor+LENGTH_TAG_LEN]
-            .copy_from_slice(&len_bytes);
+        self.mmap[self.mmap_cursor..self.mmap_cursor + LENGTH_TAG_LEN].copy_from_slice(&len_bytes);
         // Push our message.
-        self.mmap[self.mmap_cursor+LENGTH_TAG_LEN .. self.mmap_cursor+full_len]
+        self.mmap[self.mmap_cursor + LENGTH_TAG_LEN..self.mmap_cursor + full_len]
             .copy_from_slice(message.as_ref());
 
         let mut written_len = full_len;
 
-        // Zeroize the next length tag, and don't advance the cursor or current offset (so it can get overwritten)
-        if (self.current_offset + full_len as u64 + LENGTH_TAG_LEN as u64) > self.current_file_len { 
+        // Zeroize the next length tag, and don't advance the cursor or current offset
+        // (so it can get overwritten)
+        if (self.current_offset + full_len as u64 + LENGTH_TAG_LEN as u64) > self.current_file_len {
             let zeroes = [0u8; LENGTH_TAG_LEN];
-            self.mmap[self.mmap_cursor+full_len .. self.mmap_cursor+full_len+LENGTH_TAG_LEN]
+            self.mmap[self.mmap_cursor + full_len..self.mmap_cursor + full_len + LENGTH_TAG_LEN]
                 .copy_from_slice(&zeroes);
             written_len += LENGTH_TAG_LEN;
         }
-        
+
         self.mmap.flush_range(self.mmap_cursor, written_len)?;
 
         // Update our current offset counter.
@@ -192,24 +203,27 @@ impl MessageRecordBackend for MemMapBackend {
 
         Ok(())
     }
-    fn initial_offset(&self) -> u64 { 
+    fn initial_offset(&self) -> u64 {
         self.start_offset
     }
-    fn record_len(&self) -> u64 { 
+    fn record_len(&self) -> u64 {
         self.current_offset
     }
 }
 
 #[cfg(test)]
 pub mod test_util {
-    use super::{MessageRecordBackend, LengthTag};
+    use super::{LengthTag, MessageRecordBackend};
 
-    pub struct DummyBackend{}
+    pub struct DummyBackend {}
 
     impl MessageRecordBackend for DummyBackend {
         #[allow(unused_variables)]
-        fn init<T: AsRef<std::path::Path>>(file_path: T, start_offset: u64) -> Result<Self, std::io::Error> {
-            Ok(DummyBackend{})
+        fn init<T: AsRef<std::path::Path>>(
+            file_path: T,
+            start_offset: u64,
+        ) -> Result<Self, std::io::Error> {
+            Ok(DummyBackend {})
         }
 
         #[allow(unused_variables)]
@@ -217,27 +231,32 @@ pub mod test_util {
             Ok(())
         }
 
-        fn initial_offset(&self) -> u64 { 0 }
-        fn record_len(&self) -> u64 { 0 }
+        fn initial_offset(&self) -> u64 {
+            0
+        }
+        fn record_len(&self) -> u64 {
+            0
+        }
     }
-    
-    pub struct VecBackend{
+
+    pub struct VecBackend {
         pub inner: Vec<u8>,
     }
 
     impl MessageRecordBackend for VecBackend {
         #[allow(unused_variables)]
-        fn init<T: AsRef<std::path::Path>>(file_path: T, start_offset: u64) -> Result<Self, std::io::Error> {
-            Ok(
-                VecBackend{
-                    inner: Vec::default(),
-                }
-            )
+        fn init<T: AsRef<std::path::Path>>(
+            file_path: T,
+            start_offset: u64,
+        ) -> Result<Self, std::io::Error> {
+            Ok(VecBackend {
+                inner: Vec::default(),
+            })
         }
 
         #[allow(unused_variables)]
         fn write_message<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), std::io::Error> {
-            // Length-prefixing. 
+            // Length-prefixing.
             let len_bytes = (message.as_ref().len() as LengthTag).to_le_bytes();
             self.inner.extend_from_slice(&len_bytes);
             // Write message.
@@ -245,7 +264,9 @@ pub mod test_util {
             Ok(())
         }
 
-        fn initial_offset(&self) -> u64 { 0 }
+        fn initial_offset(&self) -> u64 {
+            0
+        }
         fn record_len(&self) -> u64 {
             self.inner.len() as u64
         }
@@ -257,10 +278,10 @@ pub mod test_util {
         pub count: u64,
     }
 
-    impl MultiPushBackend { 
-        pub fn new(capacity: usize) -> Self { 
+    impl MultiPushBackend {
+        pub fn new(capacity: usize) -> Self {
             let (sender, receiver) = tokio::sync::broadcast::channel(capacity);
-            MultiPushBackend { 
+            MultiPushBackend {
                 sender,
                 receiver,
                 count: 0,
@@ -270,7 +291,10 @@ pub mod test_util {
 
     impl MessageRecordBackend for MultiPushBackend {
         #[allow(unused_variables)]
-        fn init<T: AsRef<std::path::Path>>(file_path: T, start_offset: u64) -> Result<Self, std::io::Error> {
+        fn init<T: AsRef<std::path::Path>>(
+            file_path: T,
+            start_offset: u64,
+        ) -> Result<Self, std::io::Error> {
             Ok(MultiPushBackend::new(4096))
         }
 
@@ -278,7 +302,7 @@ pub mod test_util {
         fn write_message<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), std::io::Error> {
             let mut buf_make = Vec::new();
 
-            if message.as_ref().len() == 0 { 
+            if message.as_ref().is_empty() {
                 return Ok(());
             }
             // Length-prefixing.
@@ -296,10 +320,11 @@ pub mod test_util {
             Ok(())
         }
 
-        fn initial_offset(&self) -> u64 { 0 }
+        fn initial_offset(&self) -> u64 {
+            0
+        }
         fn record_len(&self) -> u64 {
             self.count
         }
     }
-
 }

--- a/sequencer_server/src/record.rs
+++ b/sequencer_server/src/record.rs
@@ -276,13 +276,23 @@ pub mod test_util {
 
         #[allow(unused_variables)]
         fn write_message<T: AsRef<[u8]>>(&mut self, message: T) -> Result<(), std::io::Error> {
+            let mut buf_make = Vec::new();
+
+            if message.as_ref().len() == 0 { 
+                return Ok(());
+            }
             // Length-prefixing.
             let len_bytes = (message.as_ref().len() as LengthTag).to_le_bytes();
-            self.sender.send(len_bytes.to_vec()).unwrap();
+
+            // Write message.
+            buf_make.extend_from_slice(&len_bytes);
             self.count += len_bytes.len() as u64;
             // Write message.
-            self.sender.send(message.as_ref().to_vec()).unwrap();
+            buf_make.extend_from_slice(message.as_ref());
             self.count += message.as_ref().len() as u64;
+
+            self.sender.send(buf_make).unwrap();
+
             Ok(())
         }
 


### PR DESCRIPTION
This is, mostly, a working sequencer server implementation. It lacks explicit "subscribe" messages, or restricting the messages to a particular peer IP address to those corresponding to a particular AppId. However, it will take in messages sent to its UDP port, push them to a memory-mapped file (with length tags), and then push them out to connected TCP clients (also with length tags).

Messages to subscribe and unsubscribe will need to be devised for TCP clients to send to this server, and more rigorous testing might be needed (I wrote the unit tests so the code and the unit tests might both be subject to my own blind spots), but it's a good start. 