### PR TITLE
Change LengthTag to u64 to fix alignment issue

### DIFF
--- a/sequencer_common/src/lib.rs
+++ b/sequencer_common/src/lib.rs
@@ -13,7 +13,7 @@ pub type EpochId = u16;
 pub type InstanceId = u16;
 pub type ClusterId = u16;
 
-pub type LengthTag = u16;
+pub type LengthTag = u64;
 
 /// Messages going into the sequencer server and
 /// being sent out by the sequencer

--- a/sequencer_server/src/record.rs
+++ b/sequencer_server/src/record.rs
@@ -380,7 +380,7 @@ impl MemMapRecordReader {
             if app_ids.is_empty() { 
                 // No whitelist, match all. 
                 // Length tag 
-                writer.write_u16_le(message.len() as u16).await?;
+                writer.write_u64_le(message.len() as LengthTag).await?;
                 // Write the message.
                 writer.write_all(message).await?;
             }
@@ -393,7 +393,7 @@ impl MemMapRecordReader {
                 };
                 if app_ids.contains(&data.app_id) { 
                     // Length tag 
-                    writer.write_u16_le(message.len() as u16).await?;
+                    writer.write_u64_le(message.len() as LengthTag).await?;
                     // Write the message.
                     writer.write_all(message).await?;
                 }


### PR DESCRIPTION
Exactly as described - Rkyv should now be able to deserialize messages read from the message bus because the length tag no longer breaks Rkyv's expected 64-bit alignment for a Sequencer message. All of the tests I've written are passing for sequencer_server.